### PR TITLE
Greenkeeper lodash 4.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## <sub>v1.0.0-alpha-6</sub>
+#### _Feb. 17, 2016_
+##### Lodash Update 4.4.0
+Removing 2 deprecated use:  
+
+	Removed _.pluck in favor of _.map with iteratee shorthand
+	Renamed _.indexBy to _.keyBy lodash 4.0.0 update

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -29,7 +29,7 @@ module.exports = {
    */
   transformAdapters (app) {
     const stores = app.config.database.stores
-    const adapters = _.pluck(stores, 'adapter')
+    const adapters = _.map(stores, 'adapter')
     return _.indexBy(adapters, 'identity')
   },
 

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -30,7 +30,7 @@ module.exports = {
   transformAdapters (app) {
     const stores = app.config.database.stores
     const adapters = _.map(stores, 'adapter')
-    return _.indexBy(adapters, 'identity')
+    return _.keyBy(adapters, 'identity')
   },
 
   /**


### PR DESCRIPTION
#### _Feb. 17, 2016_
##### Lodash Update 4.4.0

Removing 2 deprecated use:  

```
Removed _.pluck in favor of _.map with iteratee shorthand
Renamed _.indexBy to _.keBy lodash 4.0.0 update
```
