### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trailpack-waterline",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Waterline Trailpack",
   "main": "index.js",
   "scripts": {
@@ -45,7 +45,7 @@
     "mocha": "^2.4.5",
     "smokesignals": "v2-latest",
     "trails": "v2-latest",
-    "waterline-sqlite3": "^1.0.3"
+    "waterline-sqlite3": "1.0.3"
   },
   "eslintConfig": {
     "extends": "trails"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "waterline": "^0.12.1"
   },
   "devDependencies": {
-    "eslint": "^2.5.1",
+    "eslint": "^3.17.1",
     "eslint-config-trails": "^2.0.8",
     "mocha": "^2.4.5",
     "smokesignals": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -36,15 +36,15 @@
     "hoek": "^4.0.0",
     "joi": "^10.0.5",
     "lodash": "^4.17.2",
-    "trailpack": "^2.0.0-rc1",
+    "trailpack": "^2.1.2",
     "waterline": "^0.12.1"
   },
   "devDependencies": {
     "eslint": "^2.5.1",
-    "eslint-config-trails": "^2",
+    "eslint-config-trails": "^2.0.8",
     "mocha": "^2.4.5",
-    "smokesignals": "v2-latest",
-    "trails": "v2-latest",
+    "smokesignals": "^2.1.1",
+    "trails": "^2.0.2",
     "waterline-sqlite3": "1.0.3"
   },
   "eslintConfig": {


### PR DESCRIPTION
waterline-sqlite3 1.0.4 looks like it has issues with missing dependencies, locking down waterline-sqlite3 to 1.0.3 does the trick.